### PR TITLE
Add markdown decorator plugin

### DIFF
--- a/homepage/pelicanconf.py
+++ b/homepage/pelicanconf.py
@@ -39,8 +39,12 @@ DIRECT_TEMPLATES = ['sitemap']
 SITEMAP_SAVE_AS = 'sitemap.xml'
 
 PLUGIN_PATHS = ['./plugins']
-PLUGINS = ['assets']
+PLUGINS = ['decorate_content', 'assets']
 
+DECORATE_CONTENT = {
+    # maps any CSS selector to a list of classes to be added
+    # 'p': ['pv0', 'dim']
+}
 
 GITHUB_ORG = 'https://github.com/offen'
 CONTACT_EMAIL = 'hioffen@posteo.de'

--- a/homepage/plugins/decorate_content/__init__.py
+++ b/homepage/plugins/decorate_content/__init__.py
@@ -1,0 +1,1 @@
+from .decorate_content import *

--- a/homepage/plugins/decorate_content/decorate_content.py
+++ b/homepage/plugins/decorate_content/decorate_content.py
@@ -1,0 +1,33 @@
+from json import loads
+
+from pelican import signals
+from pelican.contents import Article, Page, Static
+from bs4 import BeautifulSoup
+
+
+def content_object_init(instance):
+    if isinstance(instance, (Article, Page, Static)):
+        plugin_settings = instance.settings.get("DECORATE_CONTENT", {})
+        content_overrides = (
+            instance.metadata.get("decorate_content", None)
+            if instance.metadata is not None
+            else None
+        )
+
+        settings = plugin_settings.copy()
+        settings.update(
+            loads(content_overrides) if content_overrides is not None else {}
+        )
+
+        soup = BeautifulSoup(instance._content, "html.parser")
+
+        for selector, class_names in settings.items():
+            elems = soup.find_all(selector)
+            for elem in elems:
+                elem["class"] = elem.get("class", []) + class_names
+
+        instance._content = soup.decode()
+
+
+def register():
+    signals.content_object_init.connect(content_object_init)

--- a/homepage/requirements.txt
+++ b/homepage/requirements.txt
@@ -3,3 +3,4 @@ markdown==3.1.1
 git+git://github.com/miracle2k/webassets#d1f3455e383446ca4ab0c644f326ee937e68e809
 cssmin==0.2.0
 libsass==0.19.3
+beautifulsoup4==4.8.1


### PR DESCRIPTION
This allows us to post-process Markdown and add additional classes based on CSS selectors.

To add classes to all rendered Markdown content, edit `DECORATE_CONTENT` in `pelicanconf.py` which is a mapping of `selector` => `additional_classes` like

```py
{
    'p': ['class-1'],
    'h1': ['class-2']
}
```

which run against this piece of markdown

```ms
# headline

ok

## sub

still ok
```

will render

```html
<h1 class="class-2">headline</h1>
<p class="class-1">ok</p>
<h2>sub</h2>
<p class="class-1">still ok</p>
```

---

In case these global settings do not fit  the needs of a certain page or article, the global settings can be overriden by specifying a dict of overrides in JSON notation in the article's metadata like

```md
title: Something Something
decorate_content: {"p": ["class-3"]}
---
# Hey!

This is an article
```

which will be merged into the global settings, resulting in settings like

```py
{
    'p': ['class-3'],
    'h1': ['class-2']
}
```

for this specific article.