### PR TITLE
Use cssnano instead of cssmin for building css

### DIFF
--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -1,6 +1,6 @@
 FROM nikolaik/python-nodejs:python3.7-nodejs12
 
-RUN npm install -g postcss-cli@^6.1.3 autoprefixer@^9.7.0
+RUN npm install -g postcss-cli@^6.1.3 autoprefixer@^9.7.0 cssnano@^4.1.10
 
 ENV PATH="/root/.local/bin:$PATH"
 ENV NODE_PATH="/usr/lib/node_modules"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ ARG offenaccountid
 ENV OFFEN_ACCOUNT_ID=$offenaccountid
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN npm install -g postcss-cli@^6.1.3 autoprefixer@^9.7.0 svgo@^1.3.0
+RUN npm install -g postcss-cli@^6.1.3 autoprefixer@^9.7.0 svgo@^1.3.0 cssnano@^4.1.10
 RUN apt-get update \
 	&& apt-get install -y libjpeg-progs optipng \
 	&& rm -rf /var/lib/apt/lists/*

--- a/homepage/postcss.config.js
+++ b/homepage/postcss.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   plugins: [
-    require('autoprefixer')
+    require('autoprefixer'),
+    require('cssnano')({
+      preset: 'default'
+    })
   ]
 }

--- a/homepage/requirements.txt
+++ b/homepage/requirements.txt
@@ -1,6 +1,4 @@
 pelican==4.0.1
 markdown==3.1.1
 git+git://github.com/miracle2k/webassets#d1f3455e383446ca4ab0c644f326ee937e68e809
-cssmin==0.2.0
-libsass==0.19.3
 beautifulsoup4==4.8.1

--- a/homepage/theme/templates/base.html
+++ b/homepage/theme/templates/base.html
@@ -22,7 +22,7 @@
   <link rel="canonical" href="{{ SITEURL }}/{{ href }}">
   {% endif %}
   <link rel="shortcut icon" type="image/x-icon" href="/theme/images/favicon.ico">
-  {% assets filters="postcss,cssmin", output="css/style.min.css", "css/tachyons.min.css", "css/fix.css", "css/fonts.css" %}
+  {% assets filters="postcss", output="css/style.min.css", "css/tachyons.min.css", "css/fix.css", "css/fonts.css" %}
     <link rel="stylesheet" href="/{{ ASSET_URL }}">
   {% endassets %}
   <link rel="preload" href="/theme/fonts/rubik-v9-latin-regular.woff2" as="font" crossorigin>


### PR DESCRIPTION
`cssmin` seems to be too old for correctly miniying `calc` expressions. This PR uses `cssnano` hooked into postcss instead for doing so.